### PR TITLE
Completes card 16 Github Repo

### DIFF
--- a/app/services/git_hub_service.rb
+++ b/app/services/git_hub_service.rb
@@ -10,8 +10,8 @@ class GitHubService
   private
     def github_conn
       conn = Faraday.new("https://api.github.com/") do |f|
-        # f.headers["Authorization"] = "token #{@user.token}"
-        f.params["access_token"] = @token
+        f.headers["Authorization"] = "token #{@token}"
+        # f.params["access_token"] = @token
         f.adapter Faraday.default_adapter
       end
     end
@@ -19,7 +19,6 @@ class GitHubService
     def get_json(url)
       response = github_conn.get(url)
       data = JSON.parse(response.body, symbolize_names: true)
-      # binding.pry
     end
 
 end

--- a/spec/facades/user_dashboard_facade_spec.rb
+++ b/spec/facades/user_dashboard_facade_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'UserDashboardFacade' do 
+  it 'exists' do 
+    user = create(:user)
+    facade = UserDashboardFacade.new(user)
+
+    expect(facade).to be_a(UserDashboardFacade)
+  end 
+
+  describe 'instance methods' do 
+    it '.header' do 
+      VCR.use_cassette('services/get_repos') do
+        github_user = create(:user, token: ENV["GITHUB_USER_TOKEN"])
+        facade = UserDashboardFacade.new(github_user)
+
+        expect(facade.header).to eq("5 Repos")
+      end 
+    end 
+
+    it '.repos_top_five' do 
+      VCR.use_cassette('services/get_repos') do
+        github_user = create(:user, token: ENV["GITHUB_USER_TOKEN"])
+        facade = UserDashboardFacade.new(github_user)
+
+        expect(facade.repos_top_five.count).to eq(5)
+      end 
+    end 
+  end 
+end 

--- a/spec/models/repo_spec.rb
+++ b/spec/models/repo_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Repo, type: :model do
+  it 'exists' do 
+    data = {}
+    repo = Repo.new(data)
+
+    expect(repo).to be_a(Repo)
+  end 
+
+  it 'has name and link data attributes' do 
+    data = { name: 'Jennica', html_url: 'github.com' }
+    repo = Repo.new(data)
+
+    expect(repo.name).to eq('Jennica')
+    expect(repo.link).to eq('github.com')
+  end 
+end

--- a/spec/services/git_hub_service_spec.rb
+++ b/spec/services/git_hub_service_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe 'GitHubService' do
   end 
 
   describe 'instance methods' do 
-    xit '.get_repos' do 
+    it '.get_repos' do 
       VCR.use_cassette('services/get_repos') do
         github_user = create(:user, token: ENV["GITHUB_USER_TOKEN"])
         service = GitHubService.new(github_user)
-
+      
         repos = service.get_repos
-
+   
         expect(repos.first).to have_key(:name)
         expect(repos.first).to have_key(:html_url)
         expect(repos.last).to have_key(:name)

--- a/spec/services/git_hub_service_spec.rb
+++ b/spec/services/git_hub_service_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'GitHubService' do 
+  it 'exists' do 
+    user = create(:user)
+    service = GitHubService.new(user)
+
+    expect(service).to be_a(GitHubService)
+  end 
+
+  describe 'instance methods' do 
+    xit '.get_repos' do 
+      VCR.use_cassette('services/get_repos') do
+        github_user = create(:user, token: ENV["GITHUB_USER_TOKEN"])
+        service = GitHubService.new(github_user)
+
+        repos = service.get_repos
+
+        expect(repos.first).to have_key(:name)
+        expect(repos.first).to have_key(:html_url)
+        expect(repos.last).to have_key(:name)
+        expect(repos.last).to have_key(:html_url)
+      end 
+    end 
+  end 
+end 


### PR DESCRIPTION
Adds service tests for GitHubService - all tests passing
Adds tests for UserDashboardFacade - all tests passing
Adds tests for Repo model - all tests passing
Changes Faraday connection from params to header
View works on local host. 